### PR TITLE
Row Index setting

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -452,8 +452,11 @@ class Line {
 	}
 
 	selfRender(row: any) {
-		const line = row.createEl("td");
-		line.createEl("span", { text: (this.row > 0) ? this.row.toString() : "" , cls: "line_number"});
+		
+		if (this.host.settings.rowIndex) {
+			const line = row.createEl("td");
+			line.createEl("span", { text: (this.row > 0) ? this.row.toString() : "" , cls: "line_number"});
+		}
 		
 		const source = row.createEl("td");
 		if (this.calc?.parser?.scanner) {
@@ -512,10 +515,12 @@ class Line {
 
 interface SigmaPluginSettings {
 	format: boolean;
+	rowIndex: boolean;
 }
 
 const DEFAULT_SETTINGS: SigmaPluginSettings = {
-	format: true
+	format: true,
+	rowIndex: true
 }
 
 
@@ -624,5 +629,18 @@ class SigmaSettingsTab extends PluginSettingTab {
 					await this.plugin.saveSettings();
 				})
 			})
+
+		new Setting(containerEl)
+			.setName('Row Index Column')
+			.setDesc('First Column shows the row number')
+			.addToggle(toggle => {
+				toggle
+				.setValue(this.plugin.settings.rowIndex)
+				.onChange(async (value) => {
+					this.plugin.settings.rowIndex = value;
+					await this.plugin.saveSettings();
+				})
+			})
+
 	}
 }


### PR DESCRIPTION
adds a new setting that makes the row number optional 

Row Index Column
First Column shows the row number

![image](https://user-images.githubusercontent.com/1736570/216734636-1b624a5c-62ec-40ac-91cf-e2d9054b7d88.png)
![image](https://user-images.githubusercontent.com/1736570/216734649-83baf31a-aa7b-43e6-bcc2-bd52da5c36b7.png)
